### PR TITLE
Fix os.path function name

### DIFF
--- a/audnauseum/state_machine/looper.py
+++ b/audnauseum/state_machine/looper.py
@@ -37,6 +37,8 @@ class Looper:
 
     loop: Loop
     player: Player
+    machine: Machine
+    recorder: Recorder
 
     transitions = [
         # idle state transitions
@@ -228,7 +230,7 @@ class Looper:
         if self.recorder is not None:
             self.recorder = None
         if self.loop.file_path:
-            directory = os.path.splittext(
+            directory = os.path.splitext(
                 os.path.basename(self.loop.file_path))[0]
             self.recorder = Recorder(directory=directory,
                                      track_counter=self.loop.track_count)


### PR DESCRIPTION
Apparently the function name is actually 'splitext', not 'splittext' like one might expect. 
[https://docs.python.org/3.9/library/os.path.html?highlight=os.path.splitext#os.path.splitext]

Separately, adds a couple type hints for instance variables (does not affect runtime execution)