### PR TITLE
Avoid mutable default arguments

### DIFF
--- a/audnauseum/data_models/loop.py
+++ b/audnauseum/data_models/loop.py
@@ -16,9 +16,11 @@ class Loop(object):
     _tracks: List[Track]
     _audio_cursor: int
 
-    def __init__(self, file_path=None, tracks=[], met=None, fx=None,
+    def __init__(self, file_path=None, tracks=None, met=None, fx=None,
                  audio_cursor=0):
         self._file_path = file_path
+        if tracks is None:
+            tracks = []
         self._tracks = tracks  # List of Tracks in the loop
         if met:
             self._met = met  # Initializes a metronome


### PR DESCRIPTION
Python creates a single copy of mutable default arguments across *all* function invocations, which will cause issues down the road if the default argument is being mutated (which we are doing with tracks.append). We likely would've run into a weird bug where loading a new loop still had the tracks from the old loop.

[Further information on StackOverflow](https://stackoverflow.com/questions/1132941/least-astonishment-and-the-mutable-default-argument)