### PR TITLE
Default Loop (Blank Slate) Feature & Bug Fix

### DIFF
--- a/audnauseum/gui/looper.ui
+++ b/audnauseum/gui/looper.ui
@@ -1150,7 +1150,7 @@ QPushButton:pressed {
     <enum>Qt::Horizontal</enum>
    </property>
   </widget>
-  <widget class="QSlider" name="horizontalSlider">
+  <widget class="QSlider" name="volumeSlider">
    <property name="geometry">
     <rect>
      <x>700</x>
@@ -1158,6 +1158,9 @@ QPushButton:pressed {
      <width>141</width>
      <height>21</height>
     </rect>
+   </property>
+   <property name="maximum">
+    <number>100</number>
    </property>
    <property name="orientation">
     <enum>Qt::Horizontal</enum>

--- a/audnauseum/gui/looper.ui
+++ b/audnauseum/gui/looper.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>910</width>
-    <height>500</height>
+    <height>510</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -44,7 +44,7 @@
    <property name="geometry">
     <rect>
      <x>440</x>
-     <y>375</y>
+     <y>223</y>
      <width>161</width>
      <height>61</height>
     </rect>
@@ -264,7 +264,7 @@ QPushButton:pressed {
    <property name="geometry">
     <rect>
      <x>449</x>
-     <y>100</y>
+     <y>350</y>
      <width>40</width>
      <height>40</height>
     </rect>
@@ -314,7 +314,7 @@ QPushButton:pressed {
    <property name="geometry">
     <rect>
      <x>509</x>
-     <y>110</y>
+     <y>360</y>
      <width>81</width>
      <height>20</height>
     </rect>
@@ -323,32 +323,11 @@ QPushButton:pressed {
     <string>ADD TRACK</string>
    </property>
   </widget>
-  <widget class="QLabel" name="label_12">
-   <property name="geometry">
-    <rect>
-     <x>71</x>
-     <y>380</y>
-     <width>271</width>
-     <height>41</height>
-    </rect>
-   </property>
-   <property name="font">
-    <font>
-     <pointsize>38</pointsize>
-     <weight>75</weight>
-     <italic>true</italic>
-     <bold>true</bold>
-    </font>
-   </property>
-   <property name="text">
-    <string>AUDNAUSEUM</string>
-   </property>
-  </widget>
   <widget class="QLabel" name="label_15">
    <property name="geometry">
     <rect>
      <x>510</x>
-     <y>170</y>
+     <y>420</y>
      <width>81</width>
      <height>20</height>
     </rect>
@@ -361,7 +340,7 @@ QPushButton:pressed {
    <property name="geometry">
     <rect>
      <x>450</x>
-     <y>160</y>
+     <y>410</y>
      <width>40</width>
      <height>40</height>
     </rect>
@@ -701,7 +680,7 @@ QPushButton:pressed {
   <widget class="QLabel" name="label_2">
    <property name="geometry">
     <rect>
-     <x>724</x>
+     <x>732</x>
      <y>70</y>
      <width>91</width>
      <height>16</height>
@@ -728,7 +707,7 @@ QPushButton:pressed {
    <property name="geometry">
     <rect>
      <x>450</x>
-     <y>80</y>
+     <y>330</y>
      <width>141</width>
      <height>20</height>
     </rect>
@@ -741,7 +720,7 @@ QPushButton:pressed {
    <property name="geometry">
     <rect>
      <x>460</x>
-     <y>70</y>
+     <y>320</y>
      <width>121</width>
      <height>16</height>
     </rect>
@@ -757,7 +736,7 @@ QPushButton:pressed {
    <property name="geometry">
     <rect>
      <x>467</x>
-     <y>251</y>
+     <y>100</y>
      <width>40</width>
      <height>40</height>
     </rect>
@@ -804,7 +783,7 @@ QPushButton:pressed {
    <property name="geometry">
     <rect>
      <x>532</x>
-     <y>297</y>
+     <y>146</y>
      <width>51</width>
      <height>16</height>
     </rect>
@@ -817,7 +796,7 @@ QPushButton:pressed {
    <property name="geometry">
     <rect>
      <x>537</x>
-     <y>251</y>
+     <y>100</y>
      <width>40</width>
      <height>40</height>
     </rect>
@@ -867,7 +846,7 @@ QPushButton:pressed {
    <property name="geometry">
     <rect>
      <x>450</x>
-     <y>231</y>
+     <y>80</y>
      <width>141</width>
      <height>20</height>
     </rect>
@@ -879,8 +858,8 @@ QPushButton:pressed {
   <widget class="QLabel" name="label_20">
    <property name="geometry">
     <rect>
-     <x>474</x>
-     <y>221</y>
+     <x>478</x>
+     <y>70</y>
      <width>91</width>
      <height>16</height>
     </rect>
@@ -893,7 +872,7 @@ QPushButton:pressed {
    <property name="geometry">
     <rect>
      <x>20</x>
-     <y>471</y>
+     <y>480</y>
      <width>871</width>
      <height>20</height>
     </rect>
@@ -908,7 +887,7 @@ QPushButton:pressed {
      <x>12</x>
      <y>20</y>
      <width>20</width>
-     <height>461</height>
+     <height>471</height>
     </rect>
    </property>
    <property name="orientation">
@@ -919,9 +898,9 @@ QPushButton:pressed {
    <property name="geometry">
     <rect>
      <x>881</x>
-     <y>20</y>
+     <y>19</y>
      <width>20</width>
-     <height>461</height>
+     <height>471</height>
     </rect>
    </property>
    <property name="orientation">
@@ -995,7 +974,7 @@ QPushButton:pressed {
    <property name="geometry">
     <rect>
      <x>463</x>
-     <y>297</y>
+     <y>146</y>
      <width>61</width>
      <height>16</height>
     </rect>
@@ -1008,7 +987,7 @@ QPushButton:pressed {
    <property name="geometry">
     <rect>
      <x>80</x>
-     <y>260</y>
+     <y>235</y>
      <width>121</width>
      <height>41</height>
     </rect>
@@ -1064,63 +1043,11 @@ QPushButton:pressed {
     <bool>true</bool>
    </property>
   </widget>
-  <widget class="Line" name="line_9">
-   <property name="geometry">
-    <rect>
-     <x>70</x>
-     <y>240</y>
-     <width>271</width>
-     <height>21</height>
-    </rect>
-   </property>
-   <property name="orientation">
-    <enum>Qt::Horizontal</enum>
-   </property>
-  </widget>
-  <widget class="Line" name="line_10">
-   <property name="geometry">
-    <rect>
-     <x>70</x>
-     <y>300</y>
-     <width>271</width>
-     <height>21</height>
-    </rect>
-   </property>
-   <property name="orientation">
-    <enum>Qt::Horizontal</enum>
-   </property>
-  </widget>
-  <widget class="Line" name="line_11">
-   <property name="geometry">
-    <rect>
-     <x>61</x>
-     <y>250</y>
-     <width>21</width>
-     <height>61</height>
-    </rect>
-   </property>
-   <property name="orientation">
-    <enum>Qt::Vertical</enum>
-   </property>
-  </widget>
-  <widget class="Line" name="line_12">
-   <property name="geometry">
-    <rect>
-     <x>330</x>
-     <y>250</y>
-     <width>21</width>
-     <height>61</height>
-    </rect>
-   </property>
-   <property name="orientation">
-    <enum>Qt::Vertical</enum>
-   </property>
-  </widget>
   <widget class="QPushButton" name="pushButton_save_file">
    <property name="geometry">
     <rect>
      <x>210</x>
-     <y>260</y>
+     <y>235</y>
      <width>121</width>
      <height>41</height>
     </rect>
@@ -1180,7 +1107,7 @@ QPushButton:pressed {
    <property name="geometry">
     <rect>
      <x>70</x>
-     <y>230</y>
+     <y>201</y>
      <width>271</width>
      <height>20</height>
     </rect>
@@ -1193,7 +1120,7 @@ QPushButton:pressed {
    <property name="geometry">
     <rect>
      <x>130</x>
-     <y>220</y>
+     <y>191</y>
      <width>161</width>
      <height>16</height>
     </rect>
@@ -1205,9 +1132,9 @@ QPushButton:pressed {
   <widget class="Line" name="line_14">
    <property name="geometry">
     <rect>
-     <x>461</x>
-     <y>350</y>
-     <width>121</width>
+     <x>451</x>
+     <y>200</y>
+     <width>141</width>
      <height>20</height>
     </rect>
    </property>
@@ -1219,7 +1146,7 @@ QPushButton:pressed {
    <property name="geometry">
     <rect>
      <x>489</x>
-     <y>340</y>
+     <y>190</y>
      <width>91</width>
      <height>16</height>
     </rect>
@@ -1252,6 +1179,42 @@ QPushButton:pressed {
    </property>
    <property name="text">
     <string>VOLUME</string>
+   </property>
+  </widget>
+  <widget class="QListWidget" name="listWidget">
+   <property name="geometry">
+    <rect>
+     <x>70</x>
+     <y>349</y>
+     <width>271</width>
+     <height>101</height>
+    </rect>
+   </property>
+  </widget>
+  <widget class="QLabel" name="label_9">
+   <property name="geometry">
+    <rect>
+     <x>135</x>
+     <y>320</y>
+     <width>171</width>
+     <height>16</height>
+    </rect>
+   </property>
+   <property name="text">
+    <string>CURRENT TRACK LIST</string>
+   </property>
+  </widget>
+  <widget class="Line" name="line_16">
+   <property name="geometry">
+    <rect>
+     <x>70</x>
+     <y>330</y>
+     <width>271</width>
+     <height>20</height>
+    </rect>
+   </property>
+   <property name="orientation">
+    <enum>Qt::Horizontal</enum>
    </property>
   </widget>
  </widget>

--- a/audnauseum/gui/looper.ui
+++ b/audnauseum/gui/looper.ui
@@ -13,40 +13,13 @@
   <property name="windowTitle">
    <string>AudNauseum</string>
   </property>
-  <widget class="QDial" name="dial_volume">
-   <property name="geometry">
-    <rect>
-     <x>725</x>
-     <y>364</y>
-     <width>101</width>
-     <height>81</height>
-    </rect>
-   </property>
-   <property name="styleSheet">
-    <string notr="true">QDial {
-    color: #333;
-    border: 2px solid #555;
-    border-radius: 20px;
-    border-style: outset;
-    background: qradialgradient(
-        cx: 0.3, cy: -0.4, fx: 0.3, fy: -0.4,
-        radius: 1.35, stop: 0 #fff, stop: 1 #111
-        );
-    padding: 5px;
-    }
-</string>
-   </property>
-   <property name="maximum">
-    <number>50</number>
-   </property>
-  </widget>
   <widget class="QLCDNumber" name="lcdNumber">
    <property name="geometry">
     <rect>
-     <x>440</x>
-     <y>223</y>
-     <width>161</width>
-     <height>61</height>
+     <x>416</x>
+     <y>73</y>
+     <width>201</width>
+     <height>71</height>
     </rect>
    </property>
    <property name="frameShape">
@@ -74,8 +47,8 @@
   <widget class="QPushButton" name="pushButton_record">
    <property name="geometry">
     <rect>
-     <x>151</x>
-     <y>100</y>
+     <x>466</x>
+     <y>220</y>
      <width>40</width>
      <height>40</height>
     </rect>
@@ -124,8 +97,8 @@ QPushButton:pressed {
   <widget class="QPushButton" name="pushButton_play">
    <property name="geometry">
     <rect>
-     <x>221</x>
-     <y>100</y>
+     <x>536</x>
+     <y>220</y>
      <width>40</width>
      <height>40</height>
     </rect>
@@ -174,8 +147,8 @@ QPushButton:pressed {
   <widget class="QPushButton" name="pushButton_stop">
    <property name="geometry">
     <rect>
-     <x>291</x>
-     <y>100</y>
+     <x>606</x>
+     <y>220</y>
      <width>40</width>
      <height>40</height>
     </rect>
@@ -224,8 +197,8 @@ QPushButton:pressed {
   <widget class="QLabel" name="label_6">
    <property name="geometry">
     <rect>
-     <x>157</x>
-     <y>150</y>
+     <x>472</x>
+     <y>270</y>
      <width>31</width>
      <height>16</height>
     </rect>
@@ -237,8 +210,8 @@ QPushButton:pressed {
   <widget class="QLabel" name="label_7">
    <property name="geometry">
     <rect>
-     <x>224</x>
-     <y>150</y>
+     <x>539</x>
+     <y>270</y>
      <width>31</width>
      <height>16</height>
     </rect>
@@ -250,8 +223,8 @@ QPushButton:pressed {
   <widget class="QLabel" name="label_8">
    <property name="geometry">
     <rect>
-     <x>293</x>
-     <y>150</y>
+     <x>608</x>
+     <y>270</y>
      <width>41</width>
      <height>16</height>
     </rect>
@@ -263,8 +236,8 @@ QPushButton:pressed {
   <widget class="QPushButton" name="pushButton_add_track">
    <property name="geometry">
     <rect>
-     <x>449</x>
-     <y>350</y>
+     <x>140</x>
+     <y>370</y>
      <width>40</width>
      <height>40</height>
     </rect>
@@ -313,34 +286,46 @@ QPushButton:pressed {
   <widget class="QLabel" name="label_10">
    <property name="geometry">
     <rect>
-     <x>509</x>
-     <y>360</y>
-     <width>81</width>
-     <height>20</height>
+     <x>130</x>
+     <y>417</y>
+     <width>61</width>
+     <height>31</height>
     </rect>
    </property>
    <property name="text">
     <string>ADD TRACK</string>
    </property>
+   <property name="alignment">
+    <set>Qt::AlignCenter</set>
+   </property>
+   <property name="wordWrap">
+    <bool>true</bool>
+   </property>
   </widget>
   <widget class="QLabel" name="label_15">
    <property name="geometry">
     <rect>
-     <x>510</x>
-     <y>420</y>
-     <width>81</width>
-     <height>20</height>
+     <x>207</x>
+     <y>417</y>
+     <width>71</width>
+     <height>31</height>
     </rect>
    </property>
    <property name="text">
-    <string>REM TRACK</string>
+    <string>REMOVE SELECTED</string>
+   </property>
+   <property name="alignment">
+    <set>Qt::AlignCenter</set>
+   </property>
+   <property name="wordWrap">
+    <bool>true</bool>
    </property>
   </widget>
   <widget class="QPushButton" name="pushButton_rem_track">
    <property name="geometry">
     <rect>
-     <x>450</x>
-     <y>410</y>
+     <x>220</x>
+     <y>370</y>
      <width>40</width>
      <height>40</height>
     </rect>
@@ -402,10 +387,10 @@ QPushButton:pressed {
   <widget class="QLabel" name="label_5">
    <property name="geometry">
     <rect>
-     <x>771</x>
-     <y>280</y>
-     <width>211</width>
-     <height>47</height>
+     <x>599</x>
+     <y>416</y>
+     <width>61</width>
+     <height>16</height>
     </rect>
    </property>
    <property name="text">
@@ -415,9 +400,9 @@ QPushButton:pressed {
   <widget class="QLabel" name="label_4">
    <property name="geometry">
     <rect>
-     <x>771</x>
-     <y>230</y>
-     <width>81</width>
+     <x>544</x>
+     <y>414</y>
+     <width>31</width>
      <height>20</height>
     </rect>
    </property>
@@ -428,9 +413,9 @@ QPushButton:pressed {
   <widget class="QLabel" name="label_3">
    <property name="geometry">
     <rect>
-     <x>771</x>
-     <y>170</y>
-     <width>71</width>
+     <x>467</x>
+     <y>414</y>
+     <width>41</width>
      <height>21</height>
     </rect>
    </property>
@@ -441,8 +426,8 @@ QPushButton:pressed {
   <widget class="QPushButton" name="pushButton_pitch">
    <property name="geometry">
     <rect>
-     <x>711</x>
-     <y>160</y>
+     <x>466</x>
+     <y>370</y>
      <width>40</width>
      <height>40</height>
     </rect>
@@ -491,8 +476,8 @@ QPushButton:pressed {
   <widget class="QPushButton" name="pushButton_slip">
    <property name="geometry">
     <rect>
-     <x>711</x>
-     <y>220</y>
+     <x>538</x>
+     <y>370</y>
      <width>40</width>
      <height>40</height>
     </rect>
@@ -541,8 +526,8 @@ QPushButton:pressed {
   <widget class="QPushButton" name="pushButton_reverse">
    <property name="geometry">
     <rect>
-     <x>711</x>
-     <y>280</y>
+     <x>606</x>
+     <y>370</y>
      <width>40</width>
      <height>40</height>
     </rect>
@@ -591,8 +576,8 @@ QPushButton:pressed {
   <widget class="QPushButton" name="pushButton_pan_beats">
    <property name="geometry">
     <rect>
-     <x>711</x>
-     <y>100</y>
+     <x>396</x>
+     <y>370</y>
      <width>40</width>
      <height>40</height>
     </rect>
@@ -641,9 +626,9 @@ QPushButton:pressed {
   <widget class="QLabel" name="label_16">
    <property name="geometry">
     <rect>
-     <x>771</x>
-     <y>110</y>
-     <width>71</width>
+     <x>404</x>
+     <y>414</y>
+     <width>31</width>
      <height>21</height>
     </rect>
    </property>
@@ -654,8 +639,8 @@ QPushButton:pressed {
   <widget class="Line" name="line_2">
    <property name="geometry">
     <rect>
-     <x>68</x>
-     <y>80</y>
+     <x>385</x>
+     <y>200</y>
      <width>271</width>
      <height>20</height>
     </rect>
@@ -667,8 +652,8 @@ QPushButton:pressed {
   <widget class="QLabel" name="label">
    <property name="geometry">
     <rect>
-     <x>128</x>
-     <y>70</y>
+     <x>446</x>
+     <y>190</y>
      <width>161</width>
      <height>16</height>
     </rect>
@@ -680,8 +665,8 @@ QPushButton:pressed {
   <widget class="QLabel" name="label_2">
    <property name="geometry">
     <rect>
-     <x>732</x>
-     <y>70</y>
+     <x>481</x>
+     <y>340</y>
      <width>91</width>
      <height>16</height>
     </rect>
@@ -690,53 +675,14 @@ QPushButton:pressed {
     <string>EFFECTS (FX)</string>
    </property>
   </widget>
-  <widget class="Line" name="line_3">
-   <property name="geometry">
-    <rect>
-     <x>700</x>
-     <y>80</y>
-     <width>141</width>
-     <height>20</height>
-    </rect>
-   </property>
-   <property name="orientation">
-    <enum>Qt::Horizontal</enum>
-   </property>
-  </widget>
-  <widget class="Line" name="line_4">
-   <property name="geometry">
-    <rect>
-     <x>450</x>
-     <y>330</y>
-     <width>141</width>
-     <height>20</height>
-    </rect>
-   </property>
-   <property name="orientation">
-    <enum>Qt::Horizontal</enum>
-   </property>
-  </widget>
-  <widget class="QLabel" name="label_17">
-   <property name="geometry">
-    <rect>
-     <x>460</x>
-     <y>320</y>
-     <width>121</width>
-     <height>16</height>
-    </rect>
-   </property>
-   <property name="text">
-    <string>TRACK CONTROLS</string>
-   </property>
-  </widget>
   <widget class="QPushButton" name="pushButton_metro_indicator">
    <property name="enabled">
     <bool>false</bool>
    </property>
    <property name="geometry">
     <rect>
-     <x>467</x>
-     <y>100</y>
+     <x>716</x>
+     <y>221</y>
      <width>40</width>
      <height>40</height>
     </rect>
@@ -782,8 +728,8 @@ QPushButton:pressed {
   <widget class="QLabel" name="label_19">
    <property name="geometry">
     <rect>
-     <x>532</x>
-     <y>146</y>
+     <x>781</x>
+     <y>267</y>
      <width>51</width>
      <height>16</height>
     </rect>
@@ -795,8 +741,8 @@ QPushButton:pressed {
   <widget class="QPushButton" name="pushButton_metro_on_off">
    <property name="geometry">
     <rect>
-     <x>537</x>
-     <y>100</y>
+     <x>786</x>
+     <y>221</y>
      <width>40</width>
      <height>40</height>
     </rect>
@@ -845,8 +791,8 @@ QPushButton:pressed {
   <widget class="Line" name="line_5">
    <property name="geometry">
     <rect>
-     <x>450</x>
-     <y>80</y>
+     <x>699</x>
+     <y>201</y>
      <width>141</width>
      <height>20</height>
     </rect>
@@ -858,8 +804,8 @@ QPushButton:pressed {
   <widget class="QLabel" name="label_20">
    <property name="geometry">
     <rect>
-     <x>478</x>
-     <y>70</y>
+     <x>727</x>
+     <y>191</y>
      <width>91</width>
      <height>16</height>
     </rect>
@@ -913,8 +859,8 @@ QPushButton:pressed {
    </property>
    <property name="geometry">
     <rect>
-     <x>80</x>
-     <y>100</y>
+     <x>395</x>
+     <y>220</y>
      <width>40</width>
      <height>40</height>
     </rect>
@@ -960,8 +906,8 @@ QPushButton:pressed {
   <widget class="QLabel" name="label_13">
    <property name="geometry">
     <rect>
-     <x>75</x>
-     <y>150</y>
+     <x>390</x>
+     <y>270</y>
      <width>61</width>
      <height>16</height>
     </rect>
@@ -973,8 +919,8 @@ QPushButton:pressed {
   <widget class="QLabel" name="label_18">
    <property name="geometry">
     <rect>
-     <x>463</x>
-     <y>146</y>
+     <x>712</x>
+     <y>267</y>
      <width>61</width>
      <height>16</height>
     </rect>
@@ -983,72 +929,61 @@ QPushButton:pressed {
     <string>STATUS</string>
    </property>
   </widget>
-  <widget class="QPushButton" name="pushButton_load_file">
+  <widget class="QListWidget" name="listWidget">
    <property name="geometry">
     <rect>
-     <x>80</x>
-     <y>235</y>
-     <width>121</width>
-     <height>41</height>
+     <x>70</x>
+     <y>219</y>
+     <width>271</width>
+     <height>101</height>
     </rect>
    </property>
-   <property name="minimumSize">
-    <size>
-     <width>40</width>
-     <height>40</height>
-    </size>
-   </property>
-   <property name="font">
-    <font>
-     <pointsize>20</pointsize>
-     <weight>75</weight>
-     <italic>false</italic>
-     <bold>true</bold>
-     <underline>false</underline>
-     <strikeout>false</strikeout>
-    </font>
-   </property>
-   <property name="styleSheet">
-    <string notr="true">QPushButton {
-    color: #333;
-    border: 2px solid #555;
-    border-radius: 2px;
-    border-style: outset;
-    background: qradialgradient(
-        cx: 0.3, cy: -0.4, fx: 0.3, fy: -0.4,
-        radius: 1.35, stop: 0 #fff, stop: 1 #ee3
-        );
-    padding: 5px;
-    }
-
-QPushButton:hover {
-    background: qradialgradient(
-        cx: 0.3, cy: -0.4, fx: 0.3, fy: -0.4,
-        radius: 1.35, stop: 0 #fff, stop: 1 #bbb
-        );
-    }
-
-QPushButton:pressed {
-    border-style: inset;
-    background: qradialgradient(
-        cx: 0.4, cy: -0.1, fx: 0.4, fy: -0.1,
-        radius: 1.35, stop: 0 #fff, stop: 1 #ddd
-        );
-    }</string>
+  </widget>
+  <widget class="QLabel" name="label_9">
+   <property name="geometry">
+    <rect>
+     <x>135</x>
+     <y>190</y>
+     <width>171</width>
+     <height>16</height>
+    </rect>
    </property>
    <property name="text">
-    <string>LOAD</string>
+    <string>CURRENT TRACK LIST</string>
    </property>
-   <property name="checkable">
-    <bool>true</bool>
+  </widget>
+  <widget class="Line" name="line_16">
+   <property name="geometry">
+    <rect>
+     <x>70</x>
+     <y>200</y>
+     <width>271</width>
+     <height>20</height>
+    </rect>
+   </property>
+   <property name="orientation">
+    <enum>Qt::Horizontal</enum>
+   </property>
+  </widget>
+  <widget class="QLabel" name="label_22">
+   <property name="geometry">
+    <rect>
+     <x>130</x>
+     <y>71</y>
+     <width>161</width>
+     <height>16</height>
+    </rect>
+   </property>
+   <property name="text">
+    <string>LOAD / SAVE LOOP FILE</string>
    </property>
   </widget>
   <widget class="QPushButton" name="pushButton_save_file">
    <property name="geometry">
     <rect>
-     <x>210</x>
-     <y>235</y>
-     <width>121</width>
+     <x>217</x>
+     <y>101</y>
+     <width>111</width>
      <height>41</height>
     </rect>
    </property>
@@ -1107,7 +1042,7 @@ QPushButton:pressed {
    <property name="geometry">
     <rect>
      <x>70</x>
-     <y>201</y>
+     <y>81</y>
      <width>271</width>
      <height>20</height>
     </rect>
@@ -1116,51 +1051,72 @@ QPushButton:pressed {
     <enum>Qt::Horizontal</enum>
    </property>
   </widget>
-  <widget class="QLabel" name="label_22">
+  <widget class="QPushButton" name="pushButton_load_file">
    <property name="geometry">
     <rect>
-     <x>130</x>
-     <y>191</y>
-     <width>161</width>
-     <height>16</height>
+     <x>82</x>
+     <y>101</y>
+     <width>111</width>
+     <height>41</height>
     </rect>
+   </property>
+   <property name="minimumSize">
+    <size>
+     <width>40</width>
+     <height>40</height>
+    </size>
+   </property>
+   <property name="font">
+    <font>
+     <pointsize>20</pointsize>
+     <weight>75</weight>
+     <italic>false</italic>
+     <bold>true</bold>
+     <underline>false</underline>
+     <strikeout>false</strikeout>
+    </font>
+   </property>
+   <property name="styleSheet">
+    <string notr="true">QPushButton {
+    color: #333;
+    border: 2px solid #555;
+    border-radius: 2px;
+    border-style: outset;
+    background: qradialgradient(
+        cx: 0.3, cy: -0.4, fx: 0.3, fy: -0.4,
+        radius: 1.35, stop: 0 #fff, stop: 1 #ee3
+        );
+    padding: 5px;
+    }
+
+QPushButton:hover {
+    background: qradialgradient(
+        cx: 0.3, cy: -0.4, fx: 0.3, fy: -0.4,
+        radius: 1.35, stop: 0 #fff, stop: 1 #bbb
+        );
+    }
+
+QPushButton:pressed {
+    border-style: inset;
+    background: qradialgradient(
+        cx: 0.4, cy: -0.1, fx: 0.4, fy: -0.1,
+        radius: 1.35, stop: 0 #fff, stop: 1 #ddd
+        );
+    }</string>
    </property>
    <property name="text">
-    <string>LOAD / SAVE LOOP FILE</string>
+    <string>LOAD</string>
+   </property>
+   <property name="checkable">
+    <bool>true</bool>
    </property>
   </widget>
-  <widget class="Line" name="line_14">
+  <widget class="Line" name="line_4">
    <property name="geometry">
     <rect>
-     <x>451</x>
-     <y>200</y>
-     <width>141</width>
-     <height>20</height>
-    </rect>
-   </property>
-   <property name="orientation">
-    <enum>Qt::Horizontal</enum>
-   </property>
-  </widget>
-  <widget class="QLabel" name="label_21">
-   <property name="geometry">
-    <rect>
-     <x>489</x>
-     <y>190</y>
-     <width>91</width>
-     <height>16</height>
-    </rect>
-   </property>
-   <property name="text">
-    <string>COUNTER</string>
-   </property>
-  </widget>
-  <widget class="Line" name="line_15">
-   <property name="geometry">
-    <rect>
-     <x>700</x>
+     <x>124</x>
      <y>350</y>
-     <width>141</width>
+     <width>161</width>
      <height>20</height>
     </rect>
    </property>
@@ -1168,47 +1124,24 @@ QPushButton:pressed {
     <enum>Qt::Horizontal</enum>
    </property>
   </widget>
-  <widget class="QLabel" name="label_23">
+  <widget class="QLabel" name="label_17">
    <property name="geometry">
     <rect>
-     <x>746</x>
+     <x>144</x>
      <y>340</y>
-     <width>91</width>
+     <width>121</width>
      <height>16</height>
     </rect>
    </property>
    <property name="text">
-    <string>VOLUME</string>
+    <string>TRACK CONTROLS</string>
    </property>
   </widget>
-  <widget class="QListWidget" name="listWidget">
+  <widget class="Line" name="line_3">
    <property name="geometry">
     <rect>
-     <x>70</x>
-     <y>349</y>
-     <width>271</width>
-     <height>101</height>
-    </rect>
-   </property>
-  </widget>
-  <widget class="QLabel" name="label_9">
-   <property name="geometry">
-    <rect>
-     <x>135</x>
-     <y>320</y>
-     <width>171</width>
-     <height>16</height>
-    </rect>
-   </property>
-   <property name="text">
-    <string>CURRENT TRACK LIST</string>
-   </property>
-  </widget>
-  <widget class="Line" name="line_16">
-   <property name="geometry">
-    <rect>
-     <x>70</x>
-     <y>330</y>
+     <x>385</x>
+     <y>350</y>
      <width>271</width>
      <height>20</height>
     </rect>

--- a/audnauseum/gui/looper.ui
+++ b/audnauseum/gui/looper.ui
@@ -16,9 +16,9 @@
   <widget class="QLCDNumber" name="lcdNumber">
    <property name="geometry">
     <rect>
-     <x>416</x>
+     <x>422</x>
      <y>73</y>
-     <width>201</width>
+     <width>191</width>
      <height>71</height>
     </rect>
    </property>
@@ -237,7 +237,7 @@ QPushButton:pressed {
    <property name="geometry">
     <rect>
      <x>140</x>
-     <y>370</y>
+     <y>371</y>
      <width>40</width>
      <height>40</height>
     </rect>
@@ -287,7 +287,7 @@ QPushButton:pressed {
    <property name="geometry">
     <rect>
      <x>130</x>
-     <y>417</y>
+     <y>418</y>
      <width>61</width>
      <height>31</height>
     </rect>
@@ -306,7 +306,7 @@ QPushButton:pressed {
    <property name="geometry">
     <rect>
      <x>207</x>
-     <y>417</y>
+     <y>418</y>
      <width>71</width>
      <height>31</height>
     </rect>
@@ -325,7 +325,7 @@ QPushButton:pressed {
    <property name="geometry">
     <rect>
      <x>220</x>
-     <y>370</y>
+     <y>371</y>
      <width>40</width>
      <height>40</height>
     </rect>
@@ -682,7 +682,7 @@ QPushButton:pressed {
    <property name="geometry">
     <rect>
      <x>716</x>
-     <y>221</y>
+     <y>220</y>
      <width>40</width>
      <height>40</height>
     </rect>
@@ -729,7 +729,7 @@ QPushButton:pressed {
    <property name="geometry">
     <rect>
      <x>781</x>
-     <y>267</y>
+     <y>266</y>
      <width>51</width>
      <height>16</height>
     </rect>
@@ -742,7 +742,7 @@ QPushButton:pressed {
    <property name="geometry">
     <rect>
      <x>786</x>
-     <y>221</y>
+     <y>220</y>
      <width>40</width>
      <height>40</height>
     </rect>
@@ -792,7 +792,7 @@ QPushButton:pressed {
    <property name="geometry">
     <rect>
      <x>699</x>
-     <y>201</y>
+     <y>200</y>
      <width>141</width>
      <height>20</height>
     </rect>
@@ -805,7 +805,7 @@ QPushButton:pressed {
    <property name="geometry">
     <rect>
      <x>727</x>
-     <y>191</y>
+     <y>190</y>
      <width>91</width>
      <height>16</height>
     </rect>
@@ -920,7 +920,7 @@ QPushButton:pressed {
    <property name="geometry">
     <rect>
      <x>712</x>
-     <y>267</y>
+     <y>266</y>
      <width>61</width>
      <height>16</height>
     </rect>
@@ -1115,7 +1115,7 @@ QPushButton:pressed {
    <property name="geometry">
     <rect>
      <x>124</x>
-     <y>350</y>
+     <y>351</y>
      <width>161</width>
      <height>20</height>
     </rect>
@@ -1128,7 +1128,7 @@ QPushButton:pressed {
    <property name="geometry">
     <rect>
      <x>144</x>
-     <y>340</y>
+     <y>341</y>
      <width>121</width>
      <height>16</height>
     </rect>
@@ -1148,6 +1148,71 @@ QPushButton:pressed {
    </property>
    <property name="orientation">
     <enum>Qt::Horizontal</enum>
+   </property>
+  </widget>
+  <widget class="QSlider" name="horizontalSlider">
+   <property name="geometry">
+    <rect>
+     <x>700</x>
+     <y>380</y>
+     <width>141</width>
+     <height>21</height>
+    </rect>
+   </property>
+   <property name="orientation">
+    <enum>Qt::Horizontal</enum>
+   </property>
+  </widget>
+  <widget class="QLabel" name="label_21">
+   <property name="geometry">
+    <rect>
+     <x>744</x>
+     <y>340</y>
+     <width>61</width>
+     <height>16</height>
+    </rect>
+   </property>
+   <property name="text">
+    <string>VOLUME</string>
+   </property>
+  </widget>
+  <widget class="Line" name="line_9">
+   <property name="geometry">
+    <rect>
+     <x>700</x>
+     <y>350</y>
+     <width>141</width>
+     <height>20</height>
+    </rect>
+   </property>
+   <property name="orientation">
+    <enum>Qt::Horizontal</enum>
+   </property>
+  </widget>
+  <widget class="QLabel" name="label_23">
+   <property name="geometry">
+    <rect>
+     <x>707</x>
+     <y>405</y>
+     <width>16</width>
+     <height>16</height>
+    </rect>
+   </property>
+   <property name="text">
+    <string>0</string>
+   </property>
+  </widget>
+  <widget class="QLabel" name="label_24">
+   <property name="geometry">
+    <rect>
+     <x>820</x>
+     <y>405</y>
+     <width>31</width>
+     <height>16</height>
+    </rect>
+   </property>
+   <property name="text">
+    <string>100</string>
    </property>
   </widget>
  </widget>

--- a/audnauseum/gui/ui.py
+++ b/audnauseum/gui/ui.py
@@ -20,13 +20,13 @@ def connect_all_inputs(ui, looper: Looper):
     connect_track_control_buttons(ui, looper)
     connect_fx_buttons(ui, looper)
     connect_metronome_buttons(ui, looper)
-    # connect_volume_dial(ui, looper)
+    connect_volume(ui, looper)
     initialize_lcd_display(ui, looper)
     connect_load_loop(ui, looper)
     connect_save_loop(ui, looper)
 
 
-# Dictionary wizardy modified from source code:
+# Dictionary for creating unique item names in for-loop modified from source code:
 # https://stackoverflow.com/questions/6181935/how-do-you-create-different-variable-names-while-in-a-loop
 
 def update_track_list(ui, looper: Looper):
@@ -93,11 +93,11 @@ def connect_metronome_buttons(ui, looper: Looper):
         lambda: whichbtn('metro_toggle'))
 
 
-def connect_volume_dial(ui, looper: Looper):
+def connect_volume(ui, looper: Looper):
     """VOLUME
     Add listener for volume control
     """
-    ui.dial_volume.valueChanged.connect(lambda: dial_value(ui))
+    ui.volumeSlider.valueChanged.connect(lambda: dial_value(ui))
 
 
 def initialize_lcd_display(ui, looper: Looper):
@@ -125,15 +125,8 @@ def whichbtn(_str):
 
 
 def dial_value(ui):
-    getValue = ui.dial_volume.value()
+    getValue = ui.volumeSlider.value()
     print("volume value is", str(getValue))
-
-# TODO Marked for removal
-
-
-def spinbox_value(ui):
-    getValue = ui.spinBox_context.value()
-    print("track selected is", str(getValue))
 
 
 def countdown(ui):

--- a/audnauseum/gui/ui.py
+++ b/audnauseum/gui/ui.py
@@ -20,7 +20,7 @@ def connect_all_inputs(ui, looper: Looper):
     connect_track_control_buttons(ui, looper)
     connect_fx_buttons(ui, looper)
     connect_metronome_buttons(ui, looper)
-    connect_volume_dial(ui, looper)
+    # connect_volume_dial(ui, looper)
     initialize_lcd_display(ui, looper)
     connect_load_loop(ui, looper)
     connect_save_loop(ui, looper)

--- a/audnauseum/gui/ui.py
+++ b/audnauseum/gui/ui.py
@@ -151,22 +151,22 @@ def save_loop(ui, looper: Looper) -> bool:
 
 def add_track(ui, looper: Looper) -> bool:
 
-    if not looper.state == LooperStates.IDLE:
+    # if not looper.state == LooperStates.IDLE:
 
-        options = QFileDialog.Options()
-        options |= QFileDialog.DontUseNativeDialog
-        file_path, _ = QFileDialog.getOpenFileName(
-            ui, "Choose a Track to add", "./resources/recordings", "Tracks (*.wav)", options=options)
+    options = QFileDialog.Options()
+    options |= QFileDialog.DontUseNativeDialog
+    file_path, _ = QFileDialog.getOpenFileName(
+        ui, "Choose a Track to add", "./resources/recordings", "Tracks (*.wav)", options=options)
 
-        if file_path:
-            rel_path = get_rel_path(file_path)
-            looper.load_track(rel_path)
-            return True
+    if file_path:
+        rel_path = get_rel_path(file_path)
+        looper.add_track(rel_path)
+        return True
 
         # The user canceled the add track dialog
-        return False
-    show_popup(ui)
     return False
+    # show_popup(ui)
+    # return False
 
 
 def rem_track(ui, looper: Looper) -> bool:
@@ -179,7 +179,7 @@ def rem_track(ui, looper: Looper) -> bool:
 
         if file_path:
             rel_path = get_rel_path(file_path)
-            looper.unload_track(rel_path)
+            looper.remove_track(rel_path)
             return True
 
         # The user canceled the add track dialog

--- a/audnauseum/gui/ui.py
+++ b/audnauseum/gui/ui.py
@@ -4,7 +4,8 @@ import os
 import json
 from pathlib import Path
 
-from PyQt5.QtWidgets import QFileDialog, QMessageBox
+
+from PyQt5.QtWidgets import QFileDialog, QMessageBox, QListWidget, QListWidgetItem
 from PyQt5 import uic
 
 
@@ -23,6 +24,26 @@ def connect_all_inputs(ui, looper: Looper):
     initialize_lcd_display(ui, looper)
     connect_load_loop(ui, looper)
     connect_save_loop(ui, looper)
+
+
+# Dictionary wizardy modified from source code:
+# https://stackoverflow.com/questions/6181935/how-do-you-create-different-variable-names-while-in-a-loop
+
+def update_track_list(ui, looper: Looper):
+
+    track_list = looper.loop.tracks
+    item = {}
+
+    ui.listWidget.clear()
+
+    index = 1
+    for track in track_list:
+        name = track.file_name.split('/')[-1]
+
+        item["item{0}".format(index)] = QListWidgetItem(name)
+        ui.listWidget.addItem(item["item{0}".format(index)])
+        item["item{0}".format(index)].setText(name)
+        index += 1
 
 
 def connect_transport_control_buttons(ui, looper: Looper):
@@ -95,6 +116,8 @@ def dial_value(ui):
     getValue = ui.dial_volume.value()
     print("volume value is", str(getValue))
 
+# TODO Marked for removal
+
 
 def spinbox_value(ui):
     getValue = ui.spinBox_context.value()
@@ -135,6 +158,7 @@ def load_loop(ui, looper: Looper) -> bool:
     file_path = open_file_dialog(ui)
     if file_path:
         looper.load(file_path)
+        update_track_list(ui, looper)
         return True
     # The user canceled the file dialog
     return False
@@ -151,8 +175,6 @@ def save_loop(ui, looper: Looper) -> bool:
 
 def add_track(ui, looper: Looper) -> bool:
 
-    # if not looper.state == LooperStates.IDLE:
-
     options = QFileDialog.Options()
     options |= QFileDialog.DontUseNativeDialog
     file_path, _ = QFileDialog.getOpenFileName(
@@ -161,12 +183,11 @@ def add_track(ui, looper: Looper) -> bool:
     if file_path:
         rel_path = get_rel_path(file_path)
         looper.add_track(rel_path)
+        update_track_list(ui, looper)
         return True
 
         # The user canceled the add track dialog
     return False
-    # show_popup(ui)
-    # return False
 
 
 def rem_track(ui, looper: Looper) -> bool:
@@ -180,6 +201,7 @@ def rem_track(ui, looper: Looper) -> bool:
         if file_path:
             rel_path = get_rel_path(file_path)
             looper.remove_track(rel_path)
+            update_track_list(ui, looper)
             return True
 
         # The user canceled the add track dialog

--- a/audnauseum/gui/ui.py
+++ b/audnauseum/gui/ui.py
@@ -198,10 +198,8 @@ def add_track(ui, looper: Looper) -> bool:
 def rem_track(ui, looper: Looper) -> bool:
 
     if not looper.state == LooperStates.IDLE:
-
         track = get_track(ui)
         rel_path = get_rel_path(track.text())
-        print(rel_path)
         looper.remove_track(rel_path)
         return True
 

--- a/audnauseum/gui/ui.py
+++ b/audnauseum/gui/ui.py
@@ -45,6 +45,18 @@ def update_track_list(ui, looper: Looper):
         item["item{0}".format(index)].setText(name)
         index += 1
 
+    # Select row 0 by default to prevent a NoneType error
+    ui.listWidget.setCurrentRow(0)
+    ui.listWidget.setFocus()
+
+
+def get_track(ui):
+
+    row = ui.listWidget.currentRow()
+    track = ui.listWidget.takeItem(row)
+
+    return track
+
 
 def connect_transport_control_buttons(ui, looper: Looper):
     """TRANSPORT CONTROLS
@@ -193,19 +205,13 @@ def add_track(ui, looper: Looper) -> bool:
 def rem_track(ui, looper: Looper) -> bool:
 
     if not looper.state == LooperStates.IDLE:
-        options = QFileDialog.Options()
-        options |= QFileDialog.DontUseNativeDialog
-        file_path, _ = QFileDialog.getOpenFileName(
-            ui, "Choose a Track to remove", "./resources/recordings", "Tracks (*.wav)", options=options)
 
-        if file_path:
-            rel_path = get_rel_path(file_path)
-            looper.remove_track(rel_path)
-            update_track_list(ui, looper)
-            return True
+        track = get_track(ui)
+        rel_path = get_rel_path(track.text())
+        print(rel_path)
+        looper.remove_track(rel_path)
+        return True
 
-        # The user canceled the add track dialog
-        return False
     show_popup(ui)
     return False
 

--- a/audnauseum/state_machine/looper.py
+++ b/audnauseum/state_machine/looper.py
@@ -159,7 +159,7 @@ class Looper:
         # Create a default (empty track) loop upon startup & load it
         default_path = './resources/json/default.json'
         self.write_loop(default_path)
-        # self.load_loop(default_path)
+        self.load_loop(default_path)
 
     def load_loop(self, file_path: str):
         try:
@@ -192,10 +192,8 @@ class Looper:
         print(f'{self.state=}')
 
     def load_track(self, file_path: str):
-        '''Load a Track into the looper.
-
-        Appends the track to the track_list, reads Track
-        arguments and generates a numpy array that can be used by sounddevices.
+        '''
+        Load a Track into the looper.
         '''
         # TODO beats are currently hard-coded to be 20 for all new Tracks
         try:
@@ -208,12 +206,9 @@ class Looper:
             return False
 
     def unload_track(self, file_path: str):
-        '''Remove a Track from the looper.
-
-        Removes the track from the track_list by matching first instance of the
-        pass file_path that matches.
         '''
-
+        Remove a Track from the looper.
+        '''
         try:
             self.loop.remove(file_path)
             return True

--- a/audnauseum/state_machine/looper.py
+++ b/audnauseum/state_machine/looper.py
@@ -64,8 +64,6 @@ class Looper:
          'dest': '=', 'after': 'load_track'},
         {'trigger': 'remove_track', 'source': LooperStates.LOADED,
          'dest': LooperStates.IDLE, 'conditions': ['unload_track', 'no_tracks']},
-        {'trigger': 'remove_track', 'source': LooperStates.LOADED,
-         'dest': '=', 'after': 'unload_track'},
         {'trigger': 'play', 'source': LooperStates.LOADED,
             'dest': LooperStates.PLAYING, 'after': 'play_tracks'},
         {'trigger': 'metronome', 'source': LooperStates.LOADED,

--- a/resources/json/cd_test2.json
+++ b/resources/json/cd_test2.json
@@ -1,6 +1,6 @@
 {
     "__type__": "Loop",
-    "file_path": "/Users/steve/Projects/Python/AudNauseum/resources/json/cd_test2.json",
+    "file_path": "./resources/json/cd_test2.json",
     "tracks": [
         {
             "__type__": "Track",

--- a/resources/json/cd_test2.json
+++ b/resources/json/cd_test2.json
@@ -1,0 +1,57 @@
+{
+    "__type__": "Loop",
+    "file_path": "/Users/steve/Projects/Python/AudNauseum/resources/json/cd_test2.json",
+    "tracks": [
+        {
+            "__type__": "Track",
+            "beats": 20,
+            "bpm": 8.763353845058427,
+            "file_name": "resources/recordings/Soft_Piano_Music.wav",
+            "ms_length": 136933.875,
+            "samples": 2190942,
+            "samplerate": 16000,
+            "fx": {
+                "__type__": "FxSettings",
+                "volume": 1.0,
+                "pan": 0.5,
+                "is_reversed": false,
+                "pitch_adjust": 0,
+                "slip": 0
+            }
+        },
+        {
+            "__type__": "Track",
+            "beats": 20,
+            "bpm": 8.763353845058427,
+            "file_name": "resources/recordings/Soft_Piano_Music.wav",
+            "ms_length": 136933.875,
+            "samples": 2190942,
+            "samplerate": 16000,
+            "fx": {
+                "__type__": "FxSettings",
+                "volume": 1.0,
+                "pan": 0.5,
+                "is_reversed": false,
+                "pitch_adjust": 0,
+                "slip": 0
+            }
+        }
+    ],
+    "met": {
+        "__type__": "Metronome",
+        "bpm": null,
+        "beats": null,
+        "volume": 0.5,
+        "count_in": false,
+        "is_on": false
+    },
+    "fx": {
+        "__type__": "FxSettings",
+        "volume": 1.0,
+        "pan": 0.5,
+        "is_reversed": false,
+        "pitch_adjust": 0,
+        "slip": 0
+    },
+    "audio_cursor": 0
+}

--- a/resources/json/cd_test3.json
+++ b/resources/json/cd_test3.json
@@ -1,0 +1,40 @@
+{
+    "__type__": "Loop",
+    "file_path": "/Users/steve/Projects/Python/AudNauseum/resources/json/cd_test3.json",
+    "tracks": [
+        {
+            "__type__": "Track",
+            "beats": 20,
+            "bpm": 8.763353845058427,
+            "file_name": "resources/recordings/Soft_Piano_Music.wav",
+            "ms_length": 136933.875,
+            "samples": 2190942,
+            "samplerate": 16000,
+            "fx": {
+                "__type__": "FxSettings",
+                "volume": 1.0,
+                "pan": 0.5,
+                "is_reversed": false,
+                "pitch_adjust": 0,
+                "slip": 0
+            }
+        }
+    ],
+    "met": {
+        "__type__": "Metronome",
+        "bpm": null,
+        "beats": null,
+        "volume": 0.5,
+        "count_in": false,
+        "is_on": false
+    },
+    "fx": {
+        "__type__": "FxSettings",
+        "volume": 1.0,
+        "pan": 0.5,
+        "is_reversed": false,
+        "pitch_adjust": 0,
+        "slip": 0
+    },
+    "audio_cursor": 0
+}

--- a/resources/json/cd_test3.json
+++ b/resources/json/cd_test3.json
@@ -1,6 +1,6 @@
 {
     "__type__": "Loop",
-    "file_path": "/Users/steve/Projects/Python/AudNauseum/resources/json/cd_test3.json",
+    "file_path": "./resources/json/cd_test3.json",
     "tracks": [
         {
             "__type__": "Track",

--- a/resources/json/default.json
+++ b/resources/json/default.json
@@ -1,0 +1,22 @@
+{
+    "__type__": "Loop",
+    "file_path": "./resources/json/default.json",
+    "tracks": [],
+    "met": {
+        "__type__": "Metronome",
+        "bpm": null,
+        "beats": null,
+        "volume": 0.5,
+        "count_in": false,
+        "is_on": false
+    },
+    "fx": {
+        "__type__": "FxSettings",
+        "volume": 1.0,
+        "pan": 0.5,
+        "is_reversed": false,
+        "pitch_adjust": 0,
+        "slip": 0
+    },
+    "audio_cursor": 0
+}


### PR DESCRIPTION
-fixed improper state machine calls in ui.py that were not properly allowing machine state changes.
-modified json resource files to be relative paths vice absolute path names.
-added a default loop to be created upon app startup and loaded
-added condition to transitions that if a loop is loaded with an empty track list that machine stays IDLE until at least one track is added to the loop.  added tracks_exist function to support this transition.
-added condition to transitions that if a loops tracks are reduced to zero, the machine returns to the IDLE state.  leveraged no_tracks function to support this transition.
- added gui track_list feature to show tracks in currently loaded loop
- modified gui to re-position buttons in relation to most frequently used during audio mixing.
- replaced volume dial with a volume slider to allow hard stops on left and right sides.
- fixes empty track list bug and double remove_track bug