### PR TITLE
Check for an empty queue before task_done

### DIFF
--- a/audnauseum/audio_tools/player.py
+++ b/audnauseum/audio_tools/player.py
@@ -44,7 +44,8 @@ class Player:
     def stop(self):
         self.playing = False
         self.stream.close()
-        self.input_queue.task_done()
+        if not self.input_queue.empty():
+            self.input_queue.task_done()
         self.empty_queue()
 
     def empty_queue(self):


### PR DESCRIPTION
queue.task_done will throw an error if called on an empty queue, ensure the queue is not empty

Original stack trace from Steve below:

```
Exception in thread Thread-2:
Traceback (most recent call last):
  File "/Users/steve/miniconda3/lib/python3.8/threading.py", line 932, in _bootstrap_inner
    self.run()
  File "/Users/steve/miniconda3/lib/python3.8/threading.py", line 870, in run
    self._target(*self._args, **self._kwargs)
  File "/Users/steve/Projects/Python/AudNauseum/audnauseum/audio_tools/aggregator.py", line 44, in run
    output_data = self.aggregate_list(input_data)
  File "/Users/steve/Projects/Python/AudNauseum/audnauseum/audio_tools/aggregator.py", line 74, in aggregate_list
    np.multiply(output_data, 1. / math.sqrt(num_tracks), output_data)
ZeroDivisionError: float division by zero
self.state=<LooperStates.PLAYING: 2>
Queue is empty: increase queue_size?
Traceback (most recent call last):
  File "/Users/steve/Projects/Python/AudNauseum/.venv/lib/python3.8/site-packages/transitions/core.py", line 393, in trigger
    return self.machine._process(func)
  File "/Users/steve/Projects/Python/AudNauseum/.venv/lib/python3.8/site-packages/transitions/core.py", line 1142, in _process
    return trigger()
  File "/Users/steve/Projects/Python/AudNauseum/.venv/lib/python3.8/site-packages/transitions/core.py", line 411, in _trigger
    return self._process(event_data)
  File "/Users/steve/Projects/Python/AudNauseum/.venv/lib/python3.8/site-packages/transitions/core.py", line 420, in _process
    if trans.execute(event_data):
  File "/Users/steve/Projects/Python/AudNauseum/.venv/lib/python3.8/site-packages/transitions/core.py", line 268, in execute
    event_data.machine.callbacks(itertools.chain(event_data.machine.before_state_change, self.before), event_data)
  File "/Users/steve/Projects/Python/AudNauseum/.venv/lib/python3.8/site-packages/transitions/core.py", line 1077, in callbacks
    self.callback(func, event_data)
  File "/Users/steve/Projects/Python/AudNauseum/.venv/lib/python3.8/site-packages/transitions/core.py", line 1098, in callback
    func(*event_data.args, **event_data.kwargs)
  File "/Users/steve/Projects/Python/AudNauseum/audnauseum/state_machine/looper.py", line 270, in stop_playing
    self.player.stop()
  File "/Users/steve/Projects/Python/AudNauseum/audnauseum/audio_tools/player.py", line 47, in stop
    self.input_queue.task_done()
  File "/Users/steve/miniconda3/lib/python3.8/queue.py", line 74, in task_done
    raise ValueError('task_done() called too many times')
ValueError: task_done() called too many times
```