### PR TITLE
Require Python v3.8

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,4 +1,12 @@
+import sys
+
 if __name__ == '__main__':
-    import sys
     from audnauseum.app import app
+
+    # Require at least Python v3.8
+    if sys.version_info.major < 3 or sys.version_info.minor < 8:
+        print('Error: Python v3.8+ is required.', file=sys.stderr)
+        print('Your version: ', file=sys.stderr)
+        print(sys.version, file=sys.stderr)
+
     sys.exit(app.exec_())


### PR DESCRIPTION
Add check to entry point for at least version 3.8 to ensure the user has a compatible version