### PR TITLE
Place restrictions on loop loading

### DIFF
--- a/audnauseum/gui/ui.py
+++ b/audnauseum/gui/ui.py
@@ -3,7 +3,7 @@ import time
 from pathlib import Path
 
 
-from PyQt5.QtWidgets import QFileDialog, QMessageBox, QListWidget, QListWidgetItem
+from PyQt5.QtWidgets import QFileDialog, QMessageBox, QListWidgetItem
 from PyQt5 import uic
 
 
@@ -203,6 +203,21 @@ def save_file_dialog(ui) -> str:
 
 
 def load_loop(ui, looper: Looper) -> bool:
+    """Opens a file dialog for a user to load a new Loop
+
+    Checks for a compatible state and open a file dialog to
+    pick a new loop. Load in the new Tracks if a Loop is chosen
+    or return False to indicate the state & loop did not change.
+    """
+
+    # For simplicity, only allow loading a new loop from IDLE or LOADED
+    # This could be made more flexible in the future - make sure to close
+    # all resources (streams, files) if loading a loop during play or record
+    if looper.state not in [LooperStates.IDLE, LooperStates.LOADED]:
+        msg = 'Please stop the current loop before loading a new loop.'
+        show_popup(ui, msg)
+        return False
+
     file_path = open_file_dialog(ui)
     if file_path:
         looper.load(file_path)
@@ -278,7 +293,7 @@ def transport_status(ui, looper: Looper, status):
         if status == 'record':
 
             ui.status_indicator.setStyleSheet("""
-                                                QPushButton 
+                                                QPushButton
                                                 {
                                                     color: #333;
                                                     border: 2px solid #555;
@@ -297,7 +312,7 @@ def transport_status(ui, looper: Looper, status):
         elif status == 'play':
 
             ui.status_indicator.setStyleSheet("""
-                                                QPushButton 
+                                                QPushButton
                                                 {
                                                     color: #333;
                                                     border: 2px solid #555;
@@ -317,7 +332,7 @@ def transport_status(ui, looper: Looper, status):
         else:
 
             ui.status_indicator.setStyleSheet("""
-                                                QPushButton 
+                                                QPushButton
                                                 {
                                                     color: #333;
                                                     border: 2px solid #555;

--- a/audnauseum/state_machine/looper.py
+++ b/audnauseum/state_machine/looper.py
@@ -61,6 +61,8 @@ class Looper:
          'dest': 'None'},  # Not a transition
 
         # loaded state transitions
+        {'trigger': 'load', 'source': LooperStates.LOADED,
+         'dest': '=', 'conditions': ['load_loop']},
         {'trigger': 'record', 'source': LooperStates.LOADED,
          'dest': LooperStates.PLAYING_AND_RECORDING, 'after': 'start_playing_and_recording'},
         {'trigger': 'add_track', 'source': LooperStates.LOADED,
@@ -175,6 +177,7 @@ class Looper:
 
     def set_default_channels(self):
         """Detects and sets the default sounddevice channels
+
         Checks the Host APIs of the user's OS audio settings for the
         default input and output devices.
         Sets the sounddevice default channels tuple to the capabilities
@@ -200,6 +203,11 @@ class Looper:
                 break
 
     def load_loop(self, file_path: str):
+        """Reads a JSON file using the deserializer into a Loop object
+
+        Swaps to a new Loop object given a path to a JSON file. Updates
+        mutable references in object variables.
+        """
         try:
             json_data = self.read_json(file_path)
             self.loop = json.loads(json_data, cls=ComplexDecoder)
@@ -208,8 +216,8 @@ class Looper:
             self.player.loop = self.loop
             return True
         except Exception as e:
-            print(
-                f'Exception while loading data from {file_path}\nMessage: {e}')
+            print(f'Exception while loading data from {file_path}')
+            print(f'Message: {e}')
             return False
 
     def write_loop(self, file_path: str):


### PR DESCRIPTION
Fixes issue where file dialog would open but loop wouldn't change due to no transition. 
Adds transition for LOADED state to load a different loop, and shows a message informing the user they can only load a new loop when playback and recording is stopped.