### PR TITLE
implemented volume processing in aggregator

### DIFF
--- a/audnauseum/audio_tools/aggregator.py
+++ b/audnauseum/audio_tools/aggregator.py
@@ -2,7 +2,7 @@ from audnauseum.audio_tools.wav_reader import WavReader
 from threading import Thread
 from queue import Queue
 import time
-
+import math
 import numpy as np
 
 from audnauseum.data_models.loop import Loop
@@ -112,7 +112,8 @@ class Aggregator:
             # Add element-wise in-place to reuse allocated memory
             np.add(output_data, block, output_data)
 
-        np.multiply(output_data, 1. / num_tracks, output_data)
+        np.multiply(output_data, 1. / math.sqrt(num_tracks), output_data)
+        np.multiply(output_data, self.loop.fx.volume, output_data)
         # print(f'Aggregator.aggregate_list: {time.perf_counter_ns() - start}')
         # print(time.perf_counter_ns() - start)
         return output_data

--- a/audnauseum/data_models/fx_settings.py
+++ b/audnauseum/data_models/fx_settings.py
@@ -45,7 +45,8 @@ class FxSettings:
 
     @volume.setter
     def volume(self, value):
-        self._volume = value
+        if(0. <= value <= 1.):
+            self._volume = value
 
     @property
     def pan(self):

--- a/audnauseum/state_machine/looper.py
+++ b/audnauseum/state_machine/looper.py
@@ -401,7 +401,7 @@ class Looper:
         return gui_volume
 
     def convert_gui_to_volume(self, gui_scale_volume: int) -> float:
-        loop_range = [0., 1]
+        loop_range = [0.0001, 1]
         gui_range = [0., 100.]
         loop_scale = (loop_range[1] - loop_range[0])
         gui_scale = (gui_range[1] - gui_range[0])


### PR DESCRIPTION
Adjusting the loop volume fader now changes volume during playback. 
Track volume is not implemented.  
I have some questions about how to pass track properties for a numpy_array into Aggregator.aggregate_list(). I can probably resolve those this morning, but may reach out to find out whether this is already a solved problem.
Once getting track properties in is resolved, both track_volume and reverse become easy additions.