### PR TITLE
Put disabled tooltip on metronome

### DIFF
--- a/audnauseum/gui/looper.ui
+++ b/audnauseum/gui/looper.ui
@@ -562,7 +562,7 @@ QPushButton:pressed {
     <rect>
      <x>692</x>
      <y>134</y>
-     <width>51</width>
+     <width>61</width>
      <height>16</height>
     </rect>
    </property>
@@ -584,6 +584,12 @@ QPushButton:pressed {
      <width>40</width>
      <height>40</height>
     </size>
+   </property>
+   <property name="cursor">
+    <cursorShape>ForbiddenCursor</cursorShape>
+   </property>
+   <property name="toolTip">
+    <string>Coming soon!</string>
    </property>
    <property name="styleSheet">
     <string notr="true">QPushButton {
@@ -617,7 +623,7 @@ QPushButton:pressed {
     <string/>
    </property>
    <property name="checkable">
-    <bool>true</bool>
+    <bool>false</bool>
    </property>
   </widget>
   <widget class="Line" name="line_5">


### PR DESCRIPTION
We didn't get to implement this in time, so put a tooltip to inform the user it can't be pressed

Extended width of metronome label because it was cut off on Linux.