### PR TITLE
Fix issue with duplicate tracks read

### DIFF
--- a/audnauseum/state_machine/looper.py
+++ b/audnauseum/state_machine/looper.py
@@ -302,7 +302,12 @@ class Looper:
         if self.recorder and self.recorder.recording:
             track = self.recorder.on_stop()
             self.loop.append(track)
-            self.aggregator.add_track(track.file_name, slip=track.fx.slip)
+
+            # Only inject the new track into the aggregator if playback
+            # is currently happening. If playback is stopped, it'll find
+            # the new track automatically the next time playback is started.
+            if self.player.playing:
+                self.aggregator.add_track(track.file_name, slip=track.fx.slip)
 
     def start_playing_and_recording(self, *args):
         self.start_recording()

--- a/audnauseum/state_machine/looper.py
+++ b/audnauseum/state_machine/looper.py
@@ -302,6 +302,7 @@ class Looper:
         if self.recorder and self.recorder.recording:
             track = self.recorder.on_stop()
             self.loop.append(track)
+            self.aggregator.add_track(track.file_name, slip=track.fx.slip)
 
     def start_playing_and_recording(self, *args):
         self.start_recording()

--- a/audnauseum/state_machine/looper.py
+++ b/audnauseum/state_machine/looper.py
@@ -302,7 +302,6 @@ class Looper:
         if self.recorder and self.recorder.recording:
             track = self.recorder.on_stop()
             self.loop.append(track)
-            self.aggregator.add_track(track.file_name, slip=track.fx.slip)
 
     def start_playing_and_recording(self, *args):
         self.start_recording()


### PR DESCRIPTION
Playback start already gets the freshest track list in WavReader.open_files, and playback start occurs sequentially after recording finishes. Therefore, unlike adding a track from disk during playback, we don't need to inject the new track after recording into the WavReader because that is handled in the transition functions.